### PR TITLE
Fix installation of packages on Sitecore 8.2u2 and up

### DIFF
--- a/InstallPackages.aspx
+++ b/InstallPackages.aspx
@@ -47,6 +47,7 @@
         {
           Action = UpgradeAction.Upgrade,
           Mode = InstallMode.Install,
+          ProcessingMode = ProcessingMode.All, // Remove this line on Sitecore versions below 8.2 Update-2 because it will not compile.
           Path = package
         };
         string historyPath = null;


### PR DESCRIPTION
Sitecore added the ProcessingMode property on Sitecore 8.2 Update-2. This property initializes to ProcessingMode.None and prevents the InstallPackages.aspx page to install any package, without any log to indicate the failure.

This PR fixes the issue. I added a comment to the line because it will not compile on versions of Sitecore older than 8.2u2. The users will quickly see the reason and will remove the line from their copy.

Reflection could be used to avoid the compile problem, but I felt it was too much for this simple page.